### PR TITLE
VT-5316 update version by default to next higher one

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, test_docker_build ]
 
 jobs:
 
@@ -35,7 +35,7 @@ jobs:
       with:
         context: .
         push: true
-        tags: ghcr.io/vantis-health/diga-api-service:v1.2.5-v3
+        tags: ghcr.io/vantis-health/diga-api-service:v${{ github.run_number }}
         build-args: arch=amd64
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new


### PR DESCRIPTION
The version is automatically set to the run number of the github workflow. This means, the version tag of a new container will automatically be the next major version.
It still can be set manually, but no existing version can be overwritten by accident anymore.