### PR TITLE
[VT-5616] Added GitHub Actions for deployment on Scaleway

### DIFF
--- a/.github/workflows/scaleway_registry_staging.yml
+++ b/.github/workflows/scaleway_registry_staging.yml
@@ -1,0 +1,54 @@
+name: '[STAGING] Build and Deploy'
+
+on:
+  push:
+    branches: [ develop ]
+
+concurrency:
+  group: ${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    environment: staging
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to SCW Registry
+        uses: docker/login-action@v2
+        with:
+          registry: rg.fr-par.scw.cloud/${{ vars.CONTAINER_ENVIRONMENT }}
+          username: ${{ secrets.SCW_ACCESS_KEY_ID }}
+          password: ${{ secrets.SCW_SECRET_ACCESS_KEY }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: rg.fr-par.scw.cloud/${{ vars.CONTAINER_ENVIRONMENT }}/diga_api:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+
+  Deploy:
+    runs-on: ubuntu-latest
+    needs: Build
+    steps:
+      - name: Dispatch for Deployment
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.TOKEN_FOR_TRIGGER }}
+          repository: vantis-health/therapy-infrastructure
+          event-type: staging
+          client-payload: '{"service": "diga-api"}'

--- a/.github/workflows/scaleway_registry_testing.yml
+++ b/.github/workflows/scaleway_registry_testing.yml
@@ -1,0 +1,54 @@
+name: '[TESTING] Build and Deploy'
+
+on:
+  push:
+    branches: [ testing ]
+
+concurrency:
+  group: ${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    environment: testing
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to SCW Registry
+        uses: docker/login-action@v2
+        with:
+          registry: rg.fr-par.scw.cloud/${{ vars.CONTAINER_ENVIRONMENT }}
+          username: ${{ secrets.SCW_ACCESS_KEY_ID }}
+          password: ${{ secrets.SCW_SECRET_ACCESS_KEY }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: rg.fr-par.scw.cloud/${{ vars.CONTAINER_ENVIRONMENT }}/diga_api:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+
+  Deploy:
+    runs-on: ubuntu-latest
+    needs: Build
+    steps:
+      - name: Dispatch for Deployment
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.TOKEN_FOR_TRIGGER }}
+          repository: vantis-health/therapy-infrastructure
+          event-type: testing
+          client-payload: '{"service": "diga-api"}'


### PR DESCRIPTION
Closes: [VT-5616] 

Preparation for running in a Kubernetes cluster

[VT-5616]: https://vantis-health.atlassian.net/browse/VT-5616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ