### PR TITLE
copy Krankenkassen file to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,8 @@ RUN mvn clean package
 FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-slim as production
 
 COPY --from=build /usr/src/app/target/diga-api-service-*.jar /diga-api-service.jar
+COPY ./diga_api_files  /diga_api_files
+
+EXPOSE 5000
 
 CMD ["java", "-jar", "/diga-api-service.jar"]


### PR DESCRIPTION
Changes Dockerfile for use case with kubernetes on scaleway. This means, the configuration files 'Krankenkassenverzeichnis_DIGA.xml' and the certificate file are included in the container. Additionally the port 5000 is exposed. 
This does not change the present functionalities of the container, because if other files (like another KKV_DIGA.xml version) are mounted on the container, the container files will simply be overwritten. The KKV file served through ansible-automation as done for staging, will still have higher priority on the staging server.